### PR TITLE
Moved to dev branch tarball

### DIFF
--- a/Dockerfile.pulseaudio.template
+++ b/Dockerfile.pulseaudio.template
@@ -1,7 +1,7 @@
 ARG BALENA_ARCH=%%BALENA_ARCH%%
 
 # Build process from: https://git.alpinelinux.org/aports/tree/testing/librespot/APKBUILD
-FROM balenalib/$BALENA_ARCH-alpine:edge as librespot-builder
+FROM balenalib/$BALENA_ARCH-alpine:edge AS librespot-builder
 WORKDIR /app
 
 ARG LIBRESPOT_VERSION=0.4.2

--- a/scripts/build-pulseaudio.sh
+++ b/scripts/build-pulseaudio.sh
@@ -38,8 +38,8 @@ function create_and_push_manifest() {
   docker manifest push $NAME:$TAG
 }
 
-LIBRESPOT_VERSION="0.4.2"
-DOCKER_NAMESPACE="tmigone"
+LIBRESPOT_VERSION="0.4.2-dev"
+DOCKER_NAMESPACE="brettmillerit"
 
 build_and_push_image "Dockerfile.pulseaudio.template" "${DOCKER_NAMESPACE}/librespot:$LIBRESPOT_VERSION-pulseaudio-rpi" "rpi" "linux/arm/v6" "$LIBRESPOT_VERSION"
 build_and_push_image "Dockerfile.pulseaudio.template" "${DOCKER_NAMESPACE}/librespot:$LIBRESPOT_VERSION-pulseaudio-armv7hf" "armv7hf" "linux/arm/v7" "$LIBRESPOT_VERSION"


### PR DESCRIPTION
Before this change the dockerfile was using the tarball for a tag ref `0.4.2` which was last released in 2022.

This change moves to the `dev` branch tarball which supposedly works.

I am unsure how to validate the local image I built other than it building successfully. Let me know if there is other validation required.

`docker build -f Dockerfile.pulseaudio.template --build-arg BALENA_ARCH=amd64 .`

![image](https://github.com/user-attachments/assets/a5e89b10-4ba6-4a75-a68e-e594feb2319f)

Noticed the [/plugins/spotify/Dockerfile.template](https://github.com/balena-io-experimental/balena-sound/blob/b258569343327c0091fb5e03858eb12b50f37590/plugins/spotify/Dockerfile.template) is actually using the docker hub version which I presume is run manually as the github workflow publishes to ghcr.
